### PR TITLE
Fix output for nullable types

### DIFF
--- a/compiler/generator.go
+++ b/compiler/generator.go
@@ -183,10 +183,12 @@ func (g *generator) expr(schema *jsonschema.Schema) (ast.Expr, []*ast.ImportSpec
 
 	nullable := isNullable(schema)
 	// Handle types represented by Go builtin types or some other non-named types.
-	if (nullable && len(schema.Type) != 2 || !nullable && len(schema.Type) != 1) && (schema.Go == nil || !schema.Go.TaggedUnionType) {
-		return emptyInterfaceType, nil, nil
+	if (nullable && len(schema.Type) != 2) || (!nullable && len(schema.Type) != 1) {
+		if schema.Go == nil || !schema.Go.TaggedUnionType {
+			return emptyInterfaceType, nil, nil
+		}
 	}
-	if nullable && len(schema.Type) == 2 || !nullable && len(schema.Type) == 1 {
+	if (nullable && len(schema.Type) == 2) || (!nullable && len(schema.Type) == 1) {
 		typ := schema.Type[0]
 		if len(schema.Type) == 2 {
 			if typ == jsonschema.NullType {
@@ -194,7 +196,7 @@ func (g *generator) expr(schema *jsonschema.Schema) (ast.Expr, []*ast.ImportSpec
 			}
 		}
 		if builtin := goBuiltinType(typ); builtin != "" {
-			return ast.NewIdent(goBuiltinType(typ)), nil, nil
+			return ast.NewIdent(builtin), nil, nil
 		}
 	}
 	if schema.IsEmpty {

--- a/compiler/testdata/nullable-array/schema.json
+++ b/compiler/testdata/nullable-array/schema.json
@@ -1,0 +1,22 @@
+{
+  "title": "wrapper",
+  "type": "object",
+  "properties": {
+    "array": {
+      "type": ["array", "null"],
+      "items": {
+        "title": "nullable-array-element",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/compiler/testdata/nullable-array/want.go
+++ b/compiler/testdata/nullable-array/want.go
@@ -1,0 +1,9 @@
+package p
+
+type NullableArrayElement struct {
+	A string  `json:"a,omitempty"`
+	B float64 `json:"b,omitempty"`
+}
+type Wrapper struct {
+	Array []*NullableArrayElement `json:"array,omitempty"`
+}

--- a/compiler/testdata/nullable-object/schema.json
+++ b/compiler/testdata/nullable-object/schema.json
@@ -1,0 +1,12 @@
+{
+  "title": "nullable-object",
+  "type": ["object", "null"],
+  "properties": {
+    "a": {
+      "type": "string"
+    },
+    "b": {
+      "type": "number"
+    }
+  }
+}

--- a/compiler/testdata/nullable-object/want.go
+++ b/compiler/testdata/nullable-object/want.go
@@ -1,0 +1,6 @@
+package p
+
+type NullableObject struct {
+	A string  `json:"a,omitempty"`
+	B float64 `json:"b,omitempty"`
+}

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -6,6 +6,25 @@ import (
 	"github.com/sourcegraph/go-jsonschema/jsonschema"
 )
 
+func isNullable(schema *jsonschema.Schema) bool {
+	for _, typ := range schema.Type {
+		if typ == jsonschema.NullType {
+			return true
+		}
+	}
+	return false
+}
+
+func isTypeOrNull(schema *jsonschema.Schema, typ jsonschema.PrimitiveType) bool {
+	if len(schema.Type) == 1 {
+		return schema.Type[0] == typ
+	}
+	if len(schema.Type) == 2 && isNullable(schema) {
+		return schema.Type[0] == typ || schema.Type[1] == typ
+	}
+	return false
+}
+
 func goBuiltinType(typ jsonschema.PrimitiveType) string {
 	switch typ {
 	case jsonschema.NullType:
@@ -24,7 +43,7 @@ func goBuiltinType(typ jsonschema.PrimitiveType) string {
 }
 
 func isEmittedAsGoNamedType(schema *jsonschema.Schema) bool {
-	return len(schema.Type) == 1 && schema.Type[0] == jsonschema.ObjectType
+	return isTypeOrNull(schema, jsonschema.ObjectType)
 }
 
 func derefPtrType(x ast.Expr) *ast.Ident {


### PR DESCRIPTION
When a type is declared nullable, we wouldn't need to care about it in Go for arrays and objects, but currently we fall back to just `interface{}`. This fixes it, by accounting for nullability in the type checks in the generator.

Before, `type: [array, null]` would become `interface{}`, now it becomes the same generated type it would when it was non-nullable.

Fixes the following diff, after I made them nullable.
![image](https://user-images.githubusercontent.com/19534377/136563740-451ba090-c3a4-4c7e-8c51-73f24da213b7.png)
