### PR TITLE
feat: Add "typeName" to "!go" fields for custom Go types

### DIFF
--- a/compiler/generator.go
+++ b/compiler/generator.go
@@ -191,6 +191,10 @@ func (g *generator) expr(schema *jsonschema.Schema) (ast.Expr, []*ast.ImportSpec
 			}
 		}
 		if builtin := goBuiltinType(typ); builtin != "" {
+			if schema.Go != nil && schema.Go.TypeName != "" {
+				return ast.NewIdent(schema.Go.TypeName), nil, nil
+			}
+
 			return ast.NewIdent(builtin), nil, nil
 		}
 	}

--- a/compiler/testdata/go-type-name/schema.json
+++ b/compiler/testdata/go-type-name/schema.json
@@ -1,0 +1,12 @@
+{
+  "title": "go-type-name",
+  "type": "object",
+  "properties": {
+	"a": {
+	  "type": "string",
+	  "!go": {
+		"typeName": "CustomType"
+	  }
+	}
+  }
+}

--- a/compiler/testdata/go-type-name/want.go
+++ b/compiler/testdata/go-type-name/want.go
@@ -1,0 +1,5 @@
+package p
+
+type GoTypeName struct {
+	A *CustomType `json:"a,omitempty"`
+}

--- a/jsonschema/schema.go
+++ b/jsonschema/schema.go
@@ -62,8 +62,9 @@ type Schema struct {
 
 	// Go contains Go-specific extensions that JSON Schema authors can specify.
 	Go *struct {
-		TaggedUnionType bool `json:"taggedUnionType,omitempty"`
-		Pointer         bool `json:"pointer,omitempty"`
+		TaggedUnionType bool   `json:"taggedUnionType,omitempty"`
+		Pointer         bool   `json:"pointer,omitempty"`
+		TypeName        string `json:"typeName,omitempty"`
 	} `json:"!go,omitempty"`
 }
 


### PR DESCRIPTION
Adds a new option to the `"!go"` field that allows specifying the name of the type in the generated Go code.

Use case I have in mind for this: We enter URLs in JSON schemas as strings, and sometimes they end with a `/` and sometimes they don't. This affects the way the `net/url` library actually parses the strings, so in the Sourcegraph codebase we need to remember to call `NormalizeBaseURL`, which is extremely error prone.

With this change, we can create a custom `SchemaURL` type that does normalization during JSON marshalling/unmarshalling, so we can be certain that the URL is normalized the moment it hits any Sourcegraph code, and then in the schema we can specify it like:

```json
"url": {
  "type": "string",
  "!go": {
    "typeName": "SchemaURL"
  }
}
```

and the resulting Go code will be:
```go
type CodeHostConnection struct {
  Url SchemaURL `json:"url"`
}
```