### PR TITLE
chore: bump go directive and fix trivy CVEs in go.mod

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -3,18 +3,14 @@ on:
   - push
 jobs:
   go-test:
-    strategy:
-      matrix:
-        go-version: [1.19.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - run: go test ./...

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -4,25 +4,15 @@ name: SCIP
 jobs:
   scip-go:
     runs-on: ubuntu-latest
-    env:
-      SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN }}
-      SRC_ENDPOINT: ${{ secrets.SRC_ENDPOINT }}
+    container: sourcegraph/scip-go
     steps:
-      - name: Skip upload when Sourcegraph secrets are not configured
-        if: ${{ env.SRC_ENDPOINT == '' || env.SRC_ACCESS_TOKEN == '' }}
-        run: echo "Skipping SCIP upload because SRC_ENDPOINT/SRC_ACCESS_TOKEN are not configured."
-      - uses: actions/checkout@v5
-        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
-      - name: Set up Go
-        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - name: Generate and upload SCIP index
-        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
-        uses: sourcegraph/scip-go-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sourcegraph-token: ${{ env.SRC_ACCESS_TOKEN }}
-          sourcegraph-url: ${{ env.SRC_ENDPOINT }}
-          upload: true
+      - uses: actions/checkout@v1
+      - name: Get src-cli
+        run: curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src;
+          chmod +x /usr/local/bin/src
+      - name: Set directory to safe for git
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Generate SCIP data
+        run: scip-go
+      - name: Upload SCIP data
+        run: src code-intel upload -github-token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -4,15 +4,25 @@ name: SCIP
 jobs:
   scip-go:
     runs-on: ubuntu-latest
-    container: sourcegraph/scip-go
+    env:
+      SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN }}
+      SRC_ENDPOINT: ${{ secrets.SRC_ENDPOINT }}
     steps:
-      - uses: actions/checkout@v1
-      - name: Get src-cli
-        run: curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src;
-          chmod +x /usr/local/bin/src
-      - name: Set directory to safe for git
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      - name: Generate SCIP data
-        run: scip-go
-      - name: Upload SCIP data
-        run: src code-intel upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Skip upload when Sourcegraph secrets are not configured
+        if: ${{ env.SRC_ENDPOINT == '' || env.SRC_ACCESS_TOKEN == '' }}
+        run: echo "Skipping SCIP upload because SRC_ENDPOINT/SRC_ACCESS_TOKEN are not configured."
+      - uses: actions/checkout@v5
+        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
+      - name: Set up Go
+        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Generate and upload SCIP index
+        if: ${{ env.SRC_ENDPOINT != '' && env.SRC_ACCESS_TOKEN != '' }}
+        uses: sourcegraph/scip-go-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sourcegraph-token: ${{ env.SRC_ACCESS_TOKEN }}
+          sourcegraph-url: ${{ env.SRC_ENDPOINT }}
+          upload: true

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcegraph/go-jsonschema
 
-go 1.19
+go 1.25.9


### PR DESCRIPTION
This PR was generated by Sourcegraph Batch Changes.

## Changes

- Bumps the `go` directive:
  - To `go 1.25.9` for modules currently below 1.26
  - To `go 1.26.2` for modules already on 1.26.x
- Removes any `toolchain` directive (toolchain selection is handled automatically)
- Runs `go mod tidy` to keep `go.sum` consistent with the new directive
- Fixes all CVEs reported by `trivy fs go.mod` by upgrading specific transitive
  dependencies to their minimum safe versions

## Why

Ensures a consistent, secure Go toolchain version across all first-party
`github.com/sourcegraph/*` modules that are depended on by `sourcegraph/sourcegraph`.

[_Hatched by a Sourcegraph egg._](https://egg.sgdev.dev/egg/publish/keegan/sourcegraph-go-version-and-trivy-fixes)