### PR TITLE
docs: add missing AGENTS.md (and README where missing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,6 @@ generating Go types from them.
 
 ## Setup
 
-Requires the Go toolchain matching `go.mod` (`go 1.25.9`).
-
 The official test suite is vendored as a git submodule. After cloning, run:
 
 ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,6 @@ git submodule update --init --recursive
 ## Build, test, run
 
 ```sh
-go build ./...                       # build all packages
-go test ./...                        # run the full test suite (as in CI)
-go vet ./...                         # static checks
 go run ./cmd/go-jsonschema-compiler -pkg schema -o out.go schema.json
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,6 @@ Guidance for coding agents working in `github.com/sourcegraph/go-jsonschema`, an
 **experimental** Go library for reading JSON Schema (draft-07) documents and
 generating Go types from them.
 
-## Layout
-
-- `jsonschema/` — core library: schema types, parsing, walking, URI handling.
-- `compiler/` — generates Go source from JSON Schemas (parser, resolver,
-  generators); golden-file fixtures live in `compiler/testdata/`.
-- `cmd/go-jsonschema-compiler/` — CLI that emits Go types from schema files.
-- `internal/` — test helpers (`testutil`) and the official JSON Schema test
-  suite runner (`jsonschematestsuite`).
-- `testdata/` — shared schema fixtures (e.g. the draft-07 meta-schema).
-
 ## Setup
 
 The official test suite is vendored as a git submodule. After cloning, run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+Guidance for coding agents working in `github.com/sourcegraph/go-jsonschema`, an
+**experimental** Go library for reading JSON Schema (draft-07) documents and
+generating Go types from them.
+
+## Layout
+
+- `jsonschema/` — core library: schema types, parsing, walking, URI handling.
+- `compiler/` — generates Go source from JSON Schemas (parser, resolver,
+  generators); golden-file fixtures live in `compiler/testdata/`.
+- `cmd/go-jsonschema-compiler/` — CLI that emits Go types from schema files.
+- `internal/` — test helpers (`testutil`) and the official JSON Schema test
+  suite runner (`jsonschematestsuite`).
+- `testdata/` — shared schema fixtures (e.g. the draft-07 meta-schema).
+
+## Setup
+
+Requires the Go toolchain matching `go.mod` (`go 1.25.9`).
+
+The official test suite is vendored as a git submodule. After cloning, run:
+
+```sh
+git submodule update --init --recursive
+```
+
+## Build, test, run
+
+```sh
+go build ./...                       # build all packages
+go test ./...                        # run the full test suite (as in CI)
+go vet ./...                         # static checks
+go run ./cmd/go-jsonschema-compiler -pkg schema -o out.go schema.json
+```
+
+The CLI accepts one or more JSON Schema files; `-pkg` sets the emitted package
+name and `-o` writes to a file instead of stdout.
+
+## Conventions
+
+- Standard Go formatting (`gofmt`); generated output is run through
+  `go/format`.
+- Compiler tests are golden-file based: each `compiler/testdata/<case>/` holds a
+  `schema.json` input and a `want.go` expected output. Update the corresponding
+  `want.go` when intentionally changing generated code.
+- CI (`.github/workflows/go-ci.yml`) checks out submodules recursively and runs
+  `go test ./...`; keep that command green.


### PR DESCRIPTION
Adds the missing root `AGENTS.md` for this repository (and a root `README.md` where one was also missing).

Generated by a batch change following the repository-documentation skill.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/253)