### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/cmd/go-jsonschema-compiler/go-jsonschema-compiler.go
+++ b/cmd/go-jsonschema-compiler/go-jsonschema-compiler.go
@@ -11,7 +11,6 @@ import (
 	"go/format"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/sourcegraph/go-jsonschema/compiler"
@@ -107,7 +106,7 @@ func readSchema(filename string) (*jsonschema.Schema, error) {
 // contents at path are different to data. This is to avoid triggering file
 // watchers if there is no change.
 func writeFileIfDifferent(path string, data []byte) error {
-	old, err := ioutil.ReadFile(path)
+	old, err := os.ReadFile(path)
 	if err == nil && bytes.Equal(old, data) {
 		// Skip writing
 		return nil
@@ -116,5 +115,5 @@ func writeFileIfDifferent(path string, data []byte) error {
 	// other errors can occur. In any case we just want to attempt doing a write
 	// and return that error.
 
-	return ioutil.WriteFile(path, data, 0666)
+	return os.WriteFile(path, data, 0666)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	"go/format"
 	"go/token"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -46,7 +47,7 @@ func testCompiler(t *testing.T, dir string) {
 		if entry.Mode().IsDir() {
 			continue
 		}
-		data, err := ioutil.ReadFile(filepath.Join(dir, entry.Name()))
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 		if err != nil {
 			t.Fatalf("read %s: %s", entry.Name(), err)
 		}
@@ -78,7 +79,7 @@ func testCompiler(t *testing.T, dir string) {
 
 	const goFile = "want.go"
 	if *writeWant {
-		if err := ioutil.WriteFile(filepath.Join(dir, goFile), out, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, goFile), out, 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/compiler/generator_tagged_union_type.go
+++ b/compiler/generator_tagged_union_type.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/token"
 	"reflect"
+	"slices"
 	"text/template"
 
 	"github.com/sourcegraph/go-jsonschema/jsonschema"
@@ -58,11 +59,8 @@ func (g *generator) emitTaggedUnionType(schema *jsonschema.Schema) ([]ast.Decl, 
 		prop := (*s.Properties)[discriminantPropName]
 
 		var required bool
-		for _, req := range s.Required {
-			if req == discriminantPropName {
-				required = true
-				break
-			}
+		if slices.Contains(s.Required, discriminantPropName) {
+			required = true
 		}
 		if !required {
 			return nil, nil, fmt.Errorf("invalid oneOf schema for !go.taggedUnionType extension (discriminant property %q must be required)", discriminantPropName)

--- a/compiler/parser_test.go
+++ b/compiler/parser_test.go
@@ -24,7 +24,7 @@ func TestParseSchema(t *testing.T) {
 		},
 	}
 	schemaE := &jsonschema.Schema{
-		ID:    strptr("e"),
+		ID:    new("e"),
 		Type:  jsonschema.PrimitiveTypeList{jsonschema.ArrayType},
 		Items: &jsonschema.SchemaOrSchemaList{Schema: schemaC},
 	}
@@ -35,7 +35,7 @@ func TestParseSchema(t *testing.T) {
 		},
 	}
 	schemaRoot := &jsonschema.Schema{
-		Title: strptr("root"),
+		Title: new("root"),
 		Type:  jsonschema.PrimitiveTypeList{jsonschema.ObjectType},
 		Properties: &map[string]*jsonschema.Schema{
 			"a": schemaA,
@@ -94,4 +94,5 @@ func TestParseSchema(t *testing.T) {
 	}
 }
 
-func strptr(s string) *string { return &s }
+//go:fix inline
+func strptr(s string) *string { return new(s) }

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -2,17 +2,13 @@ package compiler
 
 import (
 	"go/ast"
+	"slices"
 
 	"github.com/sourcegraph/go-jsonschema/jsonschema"
 )
 
 func isNullable(schema *jsonschema.Schema) bool {
-	for _, typ := range schema.Type {
-		if typ == jsonschema.NullType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(schema.Type, jsonschema.NullType)
 }
 
 func isTypeOrNull(schema *jsonschema.Schema, typ jsonschema.PrimitiveType) bool {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcegraph/go-jsonschema
 
-go 1.25.9
+go 1.26.4

--- a/jsonschema/schema.go
+++ b/jsonschema/schema.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // Schema is a JSON Schema draft-07 document (as specified in
@@ -72,12 +73,7 @@ type Schema struct {
 // schema.
 func (s *Schema) IsRequiredProperty(propertyName string) bool {
 	// TODO(sqs): This ignores complexity like dependencies, allOf, etc.
-	for _, p := range s.Required {
-		if p == propertyName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Required, propertyName)
 }
 
 var trueBytes = []byte("true")

--- a/jsonschema/schema_test.go
+++ b/jsonschema/schema_test.go
@@ -3,7 +3,8 @@ package jsonschema
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
+
 	"reflect"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestSample(t *testing.T) {
-	data, err := ioutil.ReadFile("../testdata/json-schema-draft-07-schema.json")
+	data, err := os.ReadFile("../testdata/json-schema-draft-07-schema.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +36,7 @@ func TestSample(t *testing.T) {
 
 func TestRaw(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
-		b, err := json.Marshal(Schema{Comment: strptr("c")})
+		b, err := json.Marshal(Schema{Comment: new("c")})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -49,10 +50,11 @@ func TestRaw(t *testing.T) {
 		if err := json.Unmarshal([]byte(input), &o); err != nil {
 			t.Fatal(err)
 		}
-		if want := (Schema{Comment: strptr("c"), Raw: (*json.RawMessage)(&input)}); !reflect.DeepEqual(o, want) {
+		if want := (Schema{Comment: new("c"), Raw: (*json.RawMessage)(&input)}); !reflect.DeepEqual(o, want) {
 			t.Errorf("got %+v, want %+v", o, want)
 		}
 	})
 }
 
-func strptr(s string) *string { return &s }
+//go:fix inline
+func strptr(s string) *string { return new(s) }


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)