### PR TITLE
Emit a map for object schemas with no properties

### DIFF
--- a/compiler/generator.go
+++ b/compiler/generator.go
@@ -167,13 +167,22 @@ func (g *generator) expr(schema *jsonschema.Schema) (ast.Expr, []*ast.ImportSpec
 		return &ast.ArrayType{Elt: elt}, imports, nil
 	}
 
-	// Handle object types that are emitted as Go map types (not named struct types).
-	if isTypeOrNull(schema, jsonschema.ObjectType) && schema.Properties == nil && schema.AdditionalProperties != nil {
-		typeExpr, imports, err := g.expr(schema.AdditionalProperties)
-		if err != nil {
-			return nil, nil, err
+	// Handle object types with no properties: emit a Go map type instead of a named struct type.
+	// The map's value type comes from additionalProperties. When additionalProperties is omitted it
+	// defaults to true per JSON Schema (any value is allowed), so use any; otherwise emit would not
+	// declare a named type for the object and the generated code would not compile.
+	if isTypeOrNull(schema, jsonschema.ObjectType) && schema.Properties == nil &&
+		(schema.Go == nil || !schema.Go.TaggedUnionType) {
+		var valueType ast.Expr = anyType
+		var imports []*ast.ImportSpec
+		if schema.AdditionalProperties != nil {
+			var err error
+			valueType, imports, err = g.expr(schema.AdditionalProperties)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
-		return &ast.MapType{Key: ast.NewIdent("string"), Value: typeExpr}, imports, nil
+		return &ast.MapType{Key: ast.NewIdent("string"), Value: valueType}, imports, nil
 	}
 
 	nullable := isNullable(schema)

--- a/compiler/testdata/bare-object-property/schema.json
+++ b/compiler/testdata/bare-object-property/schema.json
@@ -1,0 +1,10 @@
+{
+  "title": "bare-object-property",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "args": {
+      "type": "object"
+    }
+  }
+}

--- a/compiler/testdata/bare-object-property/want.go
+++ b/compiler/testdata/bare-object-property/want.go
@@ -1,0 +1,5 @@
+package p
+
+type BareObjectProperty struct {
+	Args map[string]any `json:"args,omitempty"`
+}


### PR DESCRIPTION
`{"type": "object"}` with no properties generated a field pointing at a type that never gets declared, so the output doesn't compile (`undefined: Args` in the issue). `emit` only declares a struct when there are properties; `expr` was handing back a named type anyway.

Now `expr` returns `map[string]any` for a property-less object, same as you'd get by setting `additionalProperties` yourself (and it's the JSON Schema default). Tagged unions left alone. Fixture fails if you revert it.

Closes #2